### PR TITLE
Fix runtime panic error due to index out of range

### DIFF
--- a/cmd/roles/edit.go
+++ b/cmd/roles/edit.go
@@ -82,7 +82,7 @@ var roleEditCmd = &cobra.Command{
 			log.Fatal("Too many positional arguments.")
 		}
 
-		roleId64, err := strconv.ParseInt(args[1], 10, 64)
+		roleId64, err := strconv.ParseInt(args[0], 10, 64)
 		if err != nil {
 			log.Fatal(fmt.Sprintf("Specified roleId %v is not valid.", args[0]))
 		}


### PR DESCRIPTION
```
panic: runtime error: index out of range [1] with length 1

goroutine 1 [running]:
contabo.com/cli/cntb/cmd/roles.glob..func6(0xfa8100, {0xc0001ef4f0, 0x1, 0x1})
	/builds/arcus/customer-tools/cntb/cmd/roles/edit.go:85 +0x1b9
```