### PR TITLE
Missing quotes don't allow to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 1. Configure `cntb` once to use your credentials. You can obtain them from [Customer Control Panel](https://my.contabo.com/api/details).
 
   ```sh
-  cntb config set-credentials --oauth2-clientid=<ClientId from Customer Control Panel> --oauth2-client-secret=<ClientSecret from Customer Control Panel> --oauth2-user=<API User from Customer Control Panel> --oauth2-password=<API Password from Customer Control Panel>
+  cntb config set-credentials --oauth2-clientid=<ClientId from Customer Control Panel> --oauth2-client-secret=<ClientSecret from Customer Control Panel> --oauth2-user=<API User from Customer Control Panel> --oauth2-password='<API Password from Customer Control Panel>'
   ```
 
 2. Use the CLI, e.g.


### PR DESCRIPTION
Be align with

CLIENT_ID=<ClientId from Customer Control Panel>
CLIENT_SECRET=<ClientSecret from Customer Control Panel>
API_USER=<API User from Customer Control Panel>
**API_PASSWORD='<API Password from Customer Control Panel>'**
ACCESS_TOKEN=$(curl -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" --data-urlencode "username=$API_USER" --data-urlencode "password=$API_PASSWORD" -d 'grant_type=password' 'https://auth.contabo.com/auth/realms/contabo/protocol/openid-connect/token' | jq -r '.access_token')
# get list of your instances
curl -X GET -H "Authorization: Bearer $ACCESS_TOKEN" -H "x-request-id: 51A87ECD-754E-4104-9C54-D01AD0F83406" "https://api.contabo.com/v1/compute/instances" | jq