### PR TITLE
Fixes a typo in user update help message

### DIFF
--- a/cmd/users/update.go
+++ b/cmd/users/update.go
@@ -19,8 +19,8 @@ import (
 
 var userUpdateCmd = &cobra.Command{
 	Use:   "user [userId]",
-	Short: "Updates a specific tag",
-	Long:  `Updates the specific tag by setting new values either by file input or flags / environment variables`,
+	Short: "Updates a specific user",
+	Long:  `Updates the specific user details`,
 	Run: func(cmd *cobra.Command, args []string) {
 		updateUserRequest := *userManagementClient.NewUpdateUserRequestWithDefaults()
 		content := contaboCmd.OpenStdinOrFile()


### PR DESCRIPTION
The `cntb update --help` and `cntb update user --help` output was displaying information about tag and not user update